### PR TITLE
Fix roles with role parameter in 'get_hosts'

### DIFF
--- a/mackerel/clienthde.py
+++ b/mackerel/clienthde.py
@@ -66,7 +66,7 @@ class Client(object):
         """Get hosts.
 
         :param service: Service name
-        :param roles: Service role
+        :param role: Service role
         :param name: Host name
         """
         uri = '/api/v0/hosts.json'
@@ -74,8 +74,8 @@ class Client(object):
         if kwargs.get('service', None):
             params['service'] = kwargs.get('service')
 
-        if kwargs.get('roles', None):
-            params['roles'] = kwargs.get('roles')
+        if kwargs.get('role', None):
+            params['role'] = kwargs.get('role')
 
         if kwargs.get('name', None):
             params['name'] = kwargs.get('name')


### PR DESCRIPTION
This PR fix `roles` param with `role` param in `get_hosts()`.  `roles` param is ignored.

mackerel.io support `role` param in hosts api as follows:
- https://mackerel.io/api-docs/entry/hosts#list