### PR TITLE
Support 'create_graph_definition'

### DIFF
--- a/mackerel/clienthde.py
+++ b/mackerel/clienthde.py
@@ -161,6 +161,31 @@ class Client(object):
 
         return data
 
+    ## GRAPH DEFINITION
+    def create_graph_definition(self, name, display_name, unit, metrics):
+        """Create graph definition.
+
+        :param name: Name before the last of the metric name. It must start with `custom`.
+        :param display_name: [optional] Display name of the graph.
+        :param unit: [optional] The unit in the graph. Possible values are `float`, `integer`, `percentage`, `bytes`, `bytes / sec`, `iops`.
+        :param metrics: Metrics
+        """
+
+        uri = '/api/v0/graph-defs/create'
+        headers = {'Content-Type': 'application/json'}
+        graph_definition = [
+            {
+                "name": name,
+                "displayName": display_name,
+                "unit": unit,
+                "metrics": metrics,
+            }
+        ]
+        params = json.dumps(graph_definition)
+        data = self._request(uri, method='POST', headers=headers, params=params)
+
+        return data
+
     ## SERVICE METRICS SECTION
     def post_service_metrics(self, service_name, metrics):
         """Post service metrics.


### PR DESCRIPTION
This PR add `create_graph_definition()` that post the graph definition to Mackerel.

Describe Mackerel API documents here:

https://mackerel.io/ja/api-docs/entry/host-metrics#post-graphdef